### PR TITLE
Avoid passing -std=c++0x to the C compiler.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,6 @@
 ## This assumes that the LIB_GSL variable points to working GSL libraries
-PKG_CPPFLAGS=-std=c++0x -Wall -pedantic -I$(LIB_GSL)/include -I. -I../inst/include
+PKG_CPPFLAGS=-Wall -pedantic -I$(LIB_GSL)/include -I. -I../inst/include
+PKG_CXXFLAGS=-std=c++0x
 ## 32 or 64bits?
 ifeq "${R_ARCH}" "/x64"
         PKG_LIBS=-L$(LIB_GSL)/lib/x64 -lgsl -lgslcblas  $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
This avoids passing -std=c++0x option to the C compiler (clang fails with an error when passed this option).